### PR TITLE
aquatrackApi.js

### DIFF
--- a/src/hooks/RefreshUser.jsx
+++ b/src/hooks/RefreshUser.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { selectIsSignedIn } from '../redux/auth/selectors';
 import { userInfo } from '../redux/user/operations';
@@ -6,11 +6,12 @@ import { selectUserInfo } from '../redux/user/selectors';
 import { tokenRefresh } from '../redux/auth/operations';
 import { useSearchParams } from 'react-router-dom';
 import { jwtDecode } from 'jwt-decode';
-// import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export const useRefreshUser = () => {
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const [isGoogle, setIsGoogle] = useState(false);
   const gToken = searchParams.get('token');
 
   if(gToken) {
@@ -18,7 +19,7 @@ export const useRefreshUser = () => {
     const current = new Date();
     if (decoded.exp * 1000 > current.getTime()) {
       localStorage.setItem('token', gToken);
-      // navigate('/signin');
+      setIsGoogle(true);
     }
   }
 
@@ -41,6 +42,10 @@ export const useRefreshUser = () => {
   }, [dispatch]);
   isSignedIn = useSelector(selectIsSignedIn);
   useSelector(selectUserInfo);
+
+  if(isGoogle) {
+    navigate('/signin');
+  }
 
   return [isSignedIn];
 

--- a/src/redux/services/aquatrackApi.js
+++ b/src/redux/services/aquatrackApi.js
@@ -71,6 +71,7 @@ export const uploadUserAvatar = async formData => {
   instance.defaults.headers['Content-Type'] = 'multipart/form-data';
   instance.body = formData;
   const { data } = await instance.post('/users/avatar', formData);
+  instance.defaults.headers['Content-Type'] = 'application/json';
   return data;
 };
 


### PR DESCRIPTION
знайшов ще одну помилку.
При завантаженні аватарки в заголовках встановлювався контент-тайп:

instance.defaults.headers['Content-Type'] = 'multipart/form-data';

а потім назад не мінявся. І якщо після цього зберігати ще й дані з форми, то виникала помилка.
Тому тепер після завантаження аватарки повертаю заголовок до попереднього стану:

instance.defaults.headers['Content-Type'] = 'application/json';